### PR TITLE
Fix VHDL compilation errors

### DIFF
--- a/MIPS.vhd
+++ b/MIPS.vhd
@@ -143,7 +143,7 @@ architecture Behavioral of MIPS is
         Port (
             IF_ID_Rs_addr_i      : in  STD_LOGIC_VECTOR(4 downto 0);
             IF_ID_Rt_addr_i      : in  STD_LOGIC_VECTOR(4 downto 0);
-            -- IF_ID_Inst_is_LW_i   : in  STD_LOGIC; -- Eliminado de HU según su definición
+            IF_ID_Inst_is_LW_i   : in  STD_LOGIC; -- Added this line
             EXMEM_RegWrite_i     : in  STD_LOGIC;
             EXMEM_WriteRegAddr_i : in  STD_LOGIC_VECTOR(4 downto 0);
             EXMEM_MemToReg_i     : in  STD_LOGIC;
@@ -168,6 +168,9 @@ architecture Behavioral of MIPS is
     -- Rs/Rt extraídos de IF/ID para entrada de la Unidad de Riesgos
     signal s_if_id_rs_addr_for_hu : std_logic_vector(4 downto 0);
     signal s_if_id_rt_addr_for_hu : std_logic_vector(4 downto 0);
+
+    -- Señal para verificar si la instrucción en IF/ID es LW
+    signal s_if_id_inst_is_lw : std_logic;
 
     -- Señales para conexiones del Archivo de Registros
     signal s_rf_ReadData1          : std_logic_vector(31 downto 0);
@@ -226,12 +229,16 @@ begin
     s_if_id_rs_addr_for_hu <= s_idex_Instruction_i(25 downto 21);
     s_if_id_rt_addr_for_hu <= s_idex_Instruction_i(20 downto 16);
 
+    -- Check if the instruction in IF/ID stage (output of if_idex_reg_inst) is a load word (lw)
+    -- Opcode for lw is "100011"
+    s_if_id_inst_is_lw <= '1' when s_idex_Instruction_i(31 downto 26) = "100011" else '0';
+
     -- Instanciación de la Unidad de Riesgos
     hazard_unit_inst : entity work.HazardUnit
         port map (
             IF_ID_Rs_addr_i      => s_if_id_rs_addr_for_hu,
             IF_ID_Rt_addr_i      => s_if_id_rt_addr_for_hu,
-            -- IF_ID_Inst_is_LW_i   => '0', -- Esta entrada fue eliminada de la definición de HU.
+            IF_ID_Inst_is_LW_i   => s_if_id_inst_is_lw, -- Added this line
             EXMEM_RegWrite_i     => s_memwb_RegWrite_i,     -- RegWrite desde la salida del registro EX/MEM (s_memwb_... son salidas de reg_idex_memwb)
             EXMEM_WriteRegAddr_i => s_memwb_WriteRegAddr_i, -- WriteRegAddr desde la salida del registro EX/MEM
             EXMEM_MemToReg_i     => s_memwb_MemToReg_i,     -- MemToReg desde la salida del registro EX/MEM

--- a/core/etapas/mem-wb_stage.vhd
+++ b/core/etapas/mem-wb_stage.vhd
@@ -39,16 +39,16 @@ architecture Behavioral of mem_wb_stage is
     -- Señal para el dato leído desde la Memoria de Datos
     signal s_mem_read_data : std_logic_vector(31 downto 0);
 
-    -- Componente para la Memoria de Datos (asegúrese de que coincida con su componente DataMemory real)
-    component DataMemory is
+    -- Componente para la Memoria de Datos (asegúrese de que coincida con su componente Memory real)
+    component Memory is
         port (
-            CLK         : in  std_logic;
-            RESET       : in  std_logic;
-            MemRead     : in  std_logic;
-            MemWrite    : in  std_logic;
-            Address     : in  std_logic_vector(31 downto 0);
-            WriteData   : in  std_logic_vector(31 downto 0);
-            ReadData    : out std_logic_vector(31 downto 0)
+            Clk         : in  std_logic;
+            Reset       : in  std_logic;
+            RdStb       : in  std_logic;
+            WrStb       : in  std_logic;
+            Addr        : in  std_logic_vector(31 downto 0);
+            DataIn      : in  std_logic_vector(31 downto 0);
+            DataOut     : out std_logic_vector(31 downto 0)
         );
     end component;
 
@@ -57,15 +57,15 @@ begin
     -- Instanciar Memoria de Datos
     -- La dirección para las operaciones de memoria proviene del resultado de la ALU.
     -- El dato a escribir en memoria (para SW) proviene de WriteDataMem_i.
-    data_memory_inst: entity work.DataMemory -- O la entidad específica de la librería si no está directamente en 'work'
+    data_memory_inst: entity work.Memory -- O la entidad específica de la librería si no está directamente en 'work'
         port map (
-            CLK       => clk_i,
-            RESET     => reset_i,
-            MemRead   => MemRead_i,
-            MemWrite  => MemWrite_i,
-            Address   => ALUResult_i,
-            WriteData => WriteDataMem_i,
-            ReadData  => s_mem_read_data
+            Clk       => clk_i,
+            Reset     => reset_i,
+            RdStb     => MemRead_i,
+            WrStb     => MemWrite_i,
+            Addr      => ALUResult_i,
+            DataIn    => WriteDataMem_i,
+            DataOut   => s_mem_read_data
         );
 
     -- Mux de Write-Back: Selecciona el dato a escribir en el archivo de registros.

--- a/core/unidades/alu.vhd
+++ b/core/unidades/alu.vhd
@@ -1,0 +1,43 @@
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+use IEEE.NUMERIC_STD.ALL;
+
+entity ALU is
+    port (
+        a       : in  std_logic_vector(31 downto 0);
+        b       : in  std_logic_vector(31 downto 0);
+        control : in  std_logic_vector(3 downto 0);
+        result  : out std_logic_vector(31 downto 0);
+        zero    : out std_logic
+    );
+end entity ALU;
+
+architecture Behavioral of ALU is
+    signal alu_result_internal : std_logic_vector(31 downto 0);
+begin
+    process(a, b, control)
+    begin
+        case control is
+            when "0000" => -- AND
+                alu_result_internal <= a and b;
+            when "0001" => -- OR
+                alu_result_internal <= a or b;
+            when "0010" => -- ADD
+                alu_result_internal <= std_logic_vector(signed(a) + signed(b));
+            when "0110" => -- SUB
+                alu_result_internal <= std_logic_vector(signed(a) - signed(b));
+            when "0111" => -- SLT (Set on Less Than)
+                if signed(a) < signed(b) then
+                    alu_result_internal <= std_logic_vector(to_signed(1, 32));
+                else
+                    alu_result_internal <= std_logic_vector(to_signed(0, 32));
+                end if;
+            when others => -- Default / Undefined
+                alu_result_internal <= (others => 'X'); -- Or some default value like all zeros
+        end case;
+    end process;
+
+    result <= alu_result_internal;
+    zero   <= '1' when alu_result_internal = std_logic_vector(to_signed(0, 32)) else '0';
+
+end architecture Behavioral;


### PR DESCRIPTION
I've addressed multiple VHDL compilation errors by:
1. Modifying mem-wb_stage.vhd to correctly instantiate the 'Memory' entity (formerly DataMemory) with matching port names as defined in memoria/Memory.vhd.
2. Creating a new alu.vhd in core/unidades/ with an ALU entity compatible with id-ex_stage.vhd, including a 4-bit control input and relevant ALU operations.
3. Updating MIPS.vhd to correctly declare the HazardUnit component with the 'IF_ID_Inst_is_LW_i' port and connecting it in the instantiation. I also added logic to drive this port based on whether the instruction in IF/ID is an LW.

These changes aim to resolve unknown identifier errors, unassociated port errors, and potentially the initial design unit declaration errors by allowing the compiler to correctly parse the design hierarchy.